### PR TITLE
Fix harcoded user

### DIFF
--- a/.github/workflows/buildPush.yml
+++ b/.github/workflows/buildPush.yml
@@ -14,7 +14,7 @@ env:
   IMAGE: nordlynx-transmission
   TAG: ${{ github.ref_name }}
   REVISION: ${{ github.ref_name }}
-  USER: edgd1er
+  USER: ${{ secrets.DOCKER_USER }}
 
 jobs:
   build:


### PR DESCRIPTION
Hi

People who fork your repo must change the hardcoded name in the YAML file to push to DockerHub.
It would be cool if it were moved to the secrets, as you did with a token.

What do you think?